### PR TITLE
Update GTK solar system browser

### DIFF
--- a/src/celestia/gtk/dialog-solar.cpp
+++ b/src/celestia/gtk/dialog-solar.cpp
@@ -149,8 +149,14 @@ static void addPlanetarySystemToTree(const PlanetarySystem* sys, GtkTreeStore* s
             case Body::Planet:
                 type = "Planet";
                 break;
+            case Body::DwarfPlanet:
+                type = "Dwarf Planet";
+                break;
             case Body::Moon:
                 type = "Moon";
+                break;
+            case Body::MinorMoon:
+                type = "Minor Moon";
                 break;
             case Body::Asteroid:
                 type = "Asteroid";


### PR DESCRIPTION
Add Dwarf Planets and Minor Moons to solar system browser to match Qt version
Do not add Invisible which may match Qt Reference Point because too many items potentially could be there